### PR TITLE
fixed condition for error exit in testsuite

### DIFF
--- a/bonobo-board/modules/dhbw_test.py
+++ b/bonobo-board/modules/dhbw_test.py
@@ -55,7 +55,7 @@ def main():
     dhbw_suite = suite()
     runner = TextTestRunner(verbosity=2)
     test_result = runner.run(dhbw_suite)
-    if test_result.errors != 0 and test_result.failures != 0:
+    if len(test_result.errors) != 0 or len(test_result.failures) != 0:
         exit(1)
 
 


### PR DESCRIPTION
Throw error, when the length of the test_result error-array or failure-array is not 0.